### PR TITLE
Svv fix attach supporting document

### DIFF
--- a/DirRX.PeriodicActionItemsTemplate/DirRX.PeriodicActionItemsTemplate.Server/ModuleServerFunctions.cs
+++ b/DirRX.PeriodicActionItemsTemplate/DirRX.PeriodicActionItemsTemplate.Server/ModuleServerFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sungero.Core;
@@ -113,6 +113,12 @@ namespace DirRX.PeriodicActionItemsTemplate.Server
       var setting = scheduleItem.RepeatSetting;
       
       var task = Sungero.RecordManagement.ActionItemExecutionTasks.Create();
+      
+      // Добавить документ-основание
+      var mainDocument = scheduleItem.RepeatSetting.MainDocument;
+      if (mainDocument != null)
+        task.DocumentsGroup.OfficialDocuments.Add(mainDocument);
+      
       task.AssignedBy = setting.AssignedBy;
       task.ActiveText = setting.ActionItem;
       task.IsUnderControl = setting.IsUnderControl == true;

--- a/DirRX.PeriodicActionItemsTemplate/DirRX.PeriodicActionItemsTemplate.Server/ModuleServerFunctions.cs
+++ b/DirRX.PeriodicActionItemsTemplate/DirRX.PeriodicActionItemsTemplate.Server/ModuleServerFunctions.cs
@@ -114,7 +114,6 @@ namespace DirRX.PeriodicActionItemsTemplate.Server
       
       var task = Sungero.RecordManagement.ActionItemExecutionTasks.Create();
       
-      // Добавить документ-основание
       var mainDocument = scheduleItem.RepeatSetting.MainDocument;
       if (mainDocument != null)
         task.DocumentsGroup.OfficialDocuments.Add(mainDocument);


### PR DESCRIPTION
При отправке поручений по расписанию согласно записи графика периодики, у которого указан документ- основание, ссылка на документ не отображалась в области вложений карточки задачи на исполнение поручения. Исправлено